### PR TITLE
Add "lang" field for multi-language documents

### DIFF
--- a/convert_hocr.py
+++ b/convert_hocr.py
@@ -8,7 +8,7 @@ from hocr.parser import parse
 
 debug = True
 
-fieldnames = ['pageid', 'page_dim', 'text', 'object_type', 'height', 'width', 'x0', 'x1', 'y0', 'y1']
+fieldnames = ['pageid', 'page_dim', 'text', 'object_type', 'height', 'width', 'x0', 'x1', 'y0', 'y1', 'lang']
 
 
 # shared with coalesce words, prob
@@ -53,7 +53,8 @@ def get_page_words(parsed_hocr_page, pageid):
             'text':word.text, 'width':word.box.width,
             'height':word.box.height, 'pageid':pageid,
             'page_dim':page_dim_string,
-            'object_type':'word'
+            'object_type':'word',
+            'lang':word.lang,
         }
         page_words.append(this_word)
         

--- a/hocr/page.py
+++ b/hocr/page.py
@@ -106,6 +106,8 @@ class Word(Base):
         # Find the text node.
         self.text = element.text
 
+        self.lang = element.get("lang",'')
+
     def __str__(self):
         return '<Word(%r, %r)>' % (self.text, self.box)
 


### PR DESCRIPTION
Each word now gets tagged with the language it is believed to be.

Not sure about other OCR software, but tesseract adds this.